### PR TITLE
Update minimum build-tools to fix builds

### DIFF
--- a/android-sdk-urls.md
+++ b/android-sdk-urls.md
@@ -1,8 +1,8 @@
-https://dl-ssl.google.com/android/repository/tools_r24.3.3-linux.zip
+https://dl-ssl.google.com/android/repository/tools_r25.2.4-linux.zip
 
 https://dl-ssl.google.com/android/repository/android-22_r02.zip
 
-https://dl-ssl.google.com/android/repository/platform-tools_r22-linux.zip
+https://dl-ssl.google.com/android/repository/platform-tools_r25.0.3-linux.zip
 
-https://dl-ssl.google.com/android/repository/build-tools_r22.0.1-linux.zip
+https://dl-ssl.google.com/android/repository/build-tools_r23.0.1-linux.zip
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+android-sdk-installer (1.1) stable; urgency=medium
+
+  * Update build-tools to r23.0.1 to support newer Android Support library
+    which requires 23+ version of build-tools to build apps correctly for
+    pre-Android Lollipop devices.
+    Note: Don't use latest which required JDK 8.
+  * Update platform-tools to latest version: 25.0.3
+  * Update tools to latest versoin: 25.2.4
+  * Add dependency on JRE and JDK
+
+ -- Chris Hubbard <chris_hubbard@sil.org>  Mon, 19 Dec 2016 14:57:18 -0500
+
 android-sdk-installer (1.0.1) stable; urgency=medium
 
   * Add 64-bit package

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Standards-Version: 3.9.5
 Package: android-sdk-installer
 Architecture: i386 amd64
 Pre-Depends: debconf (>= 0.5) | debconf-2.0
-Depends: ${misc:Depends}, ${dist:Depends}, unzip, wget
+Depends: ${misc:Depends}, ${dist:Depends}, unzip, wget, default-jre (>= 2:1.7) | openjdk-7-jre, default-jdk (>= 2:1.7) | openjdk-7-jdk
 Description: Installer for the Android SDK
  This package will download the required files for the Android SDK and extract
  them, or install already downloaded SDK files.

--- a/update-android-sdk
+++ b/update-android-sdk
@@ -34,10 +34,10 @@ for file in "$@";do
 	esac
 done
 
-# tools=tools_r24.3.3-linux.zip
+# tools=tools_r25.2.4-linux.zip
 # platform=android-22_r02.zip
-# platform_tools=platform-tools_r22-linux.zip
-# build_tools=build-tools_r22.0.1-linux.zip
+# platform_tools=platform-tools_r25.0.3-linux.zip
+# build_tools=build-tools_r23.0.1-linux.zip
 
 build_tools_dir=$(echo $(basename $build_tools) | sed -e 's/[^_]*_r//' -e 's/-.*//')
 platform_dir=$(echo $(basename $platform) | sed 's/_.*//')

--- a/zipfiles
+++ b/zipfiles
@@ -1,4 +1,4 @@
-tools_r24.3.3-linux.zip
+tools_r25.2.4-linux.zip
 android-22_r02.zip
-platform-tools_r22-linux.zip
-build-tools_r22.0.1-linux.zip
+platform-tools_r25.0.3-linux.zip
+build-tools_r23.0.1-linux.zip


### PR DESCRIPTION
  * Update build-tools to r23.0.1 to support newer Android Support library
    which requires 23+ version of build-tools to build apps correctly for
    pre-Android Lollipop devices.
    Note: Don't use latest which required JDK 8.
  * Update platform-tools to latest version: 25.0.3
  * Update tools to latest versoin: 25.2.4
  * Add dependency on JRE and JDK